### PR TITLE
docs: update

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 cargo add nya
 ```
 
-Install [cargo-edit](https://github.com/killercup/cargo-edit) to extends Cargo to allow you to add, remove, and upgrade dependencies by modifying your Cargo.toml file from the command line.
+Install [cargo-edit](https://github.com/killercup/cargo-edit) to extend Cargo, allowing you to add, remove, and upgrade dependencies by modifying your Cargo.toml file from the command line.
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@
 cargo add nya
 ```
 
+Install [cargo-edit](https://github.com/killercup/cargo-edit) to extends Cargo to allow you to add, remove, and upgrade dependencies by modifying your Cargo.toml file from the command line.
+
 ## Usage
 
 Currently, the way you'd use it is somewhat like this:

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -15,7 +15,7 @@ fn it_works() {
             let file = &mut files[0];
             file.content = "override".to_string();
         }),
-    ], Some("example"), None);
+    ], Some("fixtures/example"), None);
 
     if let Ok(r) = result {
         assert_eq!(r[0].content, "override".to_string());


### PR DESCRIPTION
Commit 1: for people new to rust to find cargo-edit easily. 

Commit 2: although the previous test pass, but the "example" directory is not existed, may cause misunderstanding.